### PR TITLE
Fix static addon folder configuration

### DIFF
--- a/batch-unsuspend/const.py
+++ b/batch-unsuspend/const.py
@@ -16,7 +16,7 @@ def load_meta(path: str):
 		pass
 		
 # Global variables
-ADDON_NAME = "batch-unsuspend"
+ADDON_NAME = __name__.split(".")[0]
 CONFIG = mw.addonManager.getConfig(ADDON_NAME)
 META_PATH = os.path.join(mw.pm.base, f"addons21/{ADDON_NAME}/meta.json")
 META = load_meta(META_PATH)


### PR DESCRIPTION
Fix for the issue reported here #1 

After digging around how add-ons retrieve their folder name I found this: https://github.com/glutanimate/speed-focus-mode/blob/main/src/speed_focus_mode/consts.py

Tested locally with `batch-unsuspend` and renaming it to `1886585793`.

